### PR TITLE
refactor: rewriting the cmake rules

### DIFF
--- a/bitwise/CMakeLists.txt
+++ b/bitwise/CMakeLists.txt
@@ -2,60 +2,28 @@ cmake_minimum_required(VERSION 3.8)
 
 project(bitwise)
 
-# set debug compilation flags
-get_property(DebugFlags GLOBAL PROPERTY ArkDebugFlags)
-if (DebugFlags)
-    set(CMAKE_CXX_FLAGS_DEBUG "${DebugFlags}" CACHE STRING "Debug compilation options" FORCE)
-endif()
-
-# set release compilation flags
-get_property(ReleaseFlags GLOBAL PROPERTY ArkReleaseFlags)
-if (ReleaseFlags)
-    set(CMAKE_CXX_FLAGS_RELEASE "${ReleaseFlags}" CACHE STRING "Release compilation options" FORCE)
-endif()
-
-# set linker flags
-get_property(LinkerFlags GLOBAL PROPERTY ArkLinkerFlags)
-if (LinkerFlags)
-    set(CMAKE_EXE_LINKER_FLAGS "${LinkerFlags}" CACHE STRING "Linker options" FORCE)
-endif()
-
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 include_directories(
     ${CMAKE_CURRENT_SOURCE_DIR}/../include
     ${PROJECT_SOURCE_DIR}/include
     ${ark_SOURCE_DIR}/thirdparty
-    ${ark_SOURCE_DIR}/include
-)
+    ${ark_SOURCE_DIR}/include)
 
 file(GLOB_RECURSE SOURCE_FILES
-    ${PROJECT_SOURCE_DIR}/src/*.cpp
-)
-
-list(REMOVE_ITEM SOURCE_FILES "${PROJECT_SOURCE_DIR}/../../src/main.cpp")
+    ${PROJECT_SOURCE_DIR}/src/*.cpp)
 
 add_library(${PROJECT_NAME} SHARED ${SOURCE_FILES})
 
 target_link_libraries(${PROJECT_NAME} PRIVATE ArkReactor)
-
-if (CMAKE_COMPILER_IS_GNUCXX)
-    target_link_libraries(${PROJECT_NAME} PRIVATE stdc++fs)
-endif()
-
-if (UNIX OR LINUX)
-    target_link_libraries(${PROJECT_NAME} PRIVATE ${CMAKE_DL_LIBS})
-endif()
 
 set_target_properties(
     ${PROJECT_NAME}
     PROPERTIES
         CXX_STANDARD 17
         CXX_STANDARD_REQUIRED ON
-        CXX_EXTENSIONS OFF
-)
+        CXX_EXTENSIONS OFF)
 
 add_custom_command(TARGET ${PROJECT_NAME}
     COMMAND ${CMAKE_COMMAND} -E copy
-        "$<TARGET_FILE:${PROJECT_NAME}>" ${PROJECT_SOURCE_DIR}/../../${PROJECT_NAME}.${MODULE_EXTENSION}
-)
+        "$<TARGET_FILE:${PROJECT_NAME}>" ${PROJECT_SOURCE_DIR}/../../${PROJECT_NAME}.${MODULE_EXTENSION})

--- a/console/CMakeLists.txt
+++ b/console/CMakeLists.txt
@@ -2,60 +2,28 @@ cmake_minimum_required(VERSION 3.8)
 
 project(console)
 
-# set debug compilation flags
-get_property(DebugFlags GLOBAL PROPERTY ArkDebugFlags)
-if (DebugFlags)
-    set(CMAKE_CXX_FLAGS_DEBUG "${DebugFlags}" CACHE STRING "Debug compilation options" FORCE)
-endif()
-
-# set release compilation flags
-get_property(ReleaseFlags GLOBAL PROPERTY ArkReleaseFlags)
-if (ReleaseFlags)
-    set(CMAKE_CXX_FLAGS_RELEASE "${ReleaseFlags}" CACHE STRING "Release compilation options" FORCE)
-endif()
-
-# set linker flags
-get_property(LinkerFlags GLOBAL PROPERTY ArkLinkerFlags)
-if (LinkerFlags)
-    set(CMAKE_EXE_LINKER_FLAGS "${LinkerFlags}" CACHE STRING "Linker options" FORCE)
-endif()
-
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 include_directories(
     ${CMAKE_CURRENT_SOURCE_DIR}/../include
     ${PROJECT_SOURCE_DIR}/include
     ${ark_SOURCE_DIR}/thirdparty
-    ${ark_SOURCE_DIR}/include
-)
+    ${ark_SOURCE_DIR}/include)
 
 file(GLOB_RECURSE SOURCE_FILES
-    ${PROJECT_SOURCE_DIR}/src/*.cpp
-)
-
-list(REMOVE_ITEM SOURCE_FILES "${PROJECT_SOURCE_DIR}/../../src/main.cpp")
+    ${PROJECT_SOURCE_DIR}/src/*.cpp)
 
 add_library(${PROJECT_NAME} SHARED ${SOURCE_FILES})
 
 target_link_libraries(${PROJECT_NAME} PRIVATE ArkReactor)
-
-if (CMAKE_COMPILER_IS_GNUCXX)
-    target_link_libraries(${PROJECT_NAME} PRIVATE stdc++fs)
-endif()
-
-if (UNIX OR LINUX)
-    target_link_libraries(${PROJECT_NAME} PRIVATE ${CMAKE_DL_LIBS})
-endif()
 
 set_target_properties(
     ${PROJECT_NAME}
     PROPERTIES
         CXX_STANDARD 17
         CXX_STANDARD_REQUIRED ON
-        CXX_EXTENSIONS OFF
-)
+        CXX_EXTENSIONS OFF)
 
 add_custom_command(TARGET ${PROJECT_NAME}
     COMMAND ${CMAKE_COMMAND} -E copy
-        "$<TARGET_FILE:${PROJECT_NAME}>" ${PROJECT_SOURCE_DIR}/../../${PROJECT_NAME}.${MODULE_EXTENSION}
-)
+        "$<TARGET_FILE:${PROJECT_NAME}>" ${PROJECT_SOURCE_DIR}/../../${PROJECT_NAME}.${MODULE_EXTENSION})

--- a/hash/CMakeLists.txt
+++ b/hash/CMakeLists.txt
@@ -2,24 +2,6 @@ cmake_minimum_required(VERSION 3.8)
 
 project(hash)
 
-# set debug compilation flags
-get_property(DebugFlags GLOBAL PROPERTY ArkDebugFlags)
-if (DebugFlags)
-    set(CMAKE_CXX_FLAGS_DEBUG "${DebugFlags}" CACHE STRING "Debug compilation options" FORCE)
-endif()
-
-# set release compilation flags
-get_property(ReleaseFlags GLOBAL PROPERTY ArkReleaseFlags)
-if (ReleaseFlags)
-    set(CMAKE_CXX_FLAGS_RELEASE "${ReleaseFlags}" CACHE STRING "Release compilation options" FORCE)
-endif()
-
-# set linker flags
-get_property(LinkerFlags GLOBAL PROPERTY ArkLinkerFlags)
-if (LinkerFlags)
-    set(CMAKE_EXE_LINKER_FLAGS "${LinkerFlags}" CACHE STRING "Linker options" FORCE)
-endif()
-
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 include_directories(
@@ -27,36 +9,22 @@ include_directories(
     ${PROJECT_SOURCE_DIR}/include
     ${ark_SOURCE_DIR}/thirdparty
     ${ark_SOURCE_DIR}/include
-    ${ark_SOURCE_DIR}/lib/picosha2/
-)
+    ${ark_SOURCE_DIR}/lib/picosha2/)
 
 file(GLOB_RECURSE SOURCE_FILES
-    ${PROJECT_SOURCE_DIR}/src/*.cpp
-)
-
-list(REMOVE_ITEM SOURCE_FILES "${PROJECT_SOURCE_DIR}/../../src/main.cpp")
+    ${PROJECT_SOURCE_DIR}/src/*.cpp)
 
 add_library(${PROJECT_NAME} SHARED ${SOURCE_FILES})
 
 target_link_libraries(${PROJECT_NAME} PRIVATE ArkReactor)
-
-if (CMAKE_COMPILER_IS_GNUCXX)
-    target_link_libraries(${PROJECT_NAME} PRIVATE stdc++fs)
-endif()
-
-if (UNIX OR LINUX)
-    target_link_libraries(${PROJECT_NAME} PRIVATE ${CMAKE_DL_LIBS})
-endif()
 
 set_target_properties(
     ${PROJECT_NAME}
     PROPERTIES
         CXX_STANDARD 17
         CXX_STANDARD_REQUIRED ON
-        CXX_EXTENSIONS OFF
-)
+        CXX_EXTENSIONS OFF)
 
 add_custom_command(TARGET ${PROJECT_NAME}
     COMMAND ${CMAKE_COMMAND} -E copy
-        "$<TARGET_FILE:${PROJECT_NAME}>" ${PROJECT_SOURCE_DIR}/../../${PROJECT_NAME}.${MODULE_EXTENSION}
-)
+        "$<TARGET_FILE:${PROJECT_NAME}>" ${PROJECT_SOURCE_DIR}/../../${PROJECT_NAME}.${MODULE_EXTENSION})

--- a/http/CMakeLists.txt
+++ b/http/CMakeLists.txt
@@ -2,63 +2,31 @@ cmake_minimum_required(VERSION 3.8)
 
 project(http)
 
-# set debug compilation flags
-get_property(DebugFlags GLOBAL PROPERTY ArkDebugFlags)
-if (DebugFlags)
-    set(CMAKE_CXX_FLAGS_DEBUG "${DebugFlags}" CACHE STRING "Debug compilation options" FORCE)
-endif()
-
-# set release compilation flags
-get_property(ReleaseFlags GLOBAL PROPERTY ArkReleaseFlags)
-if (ReleaseFlags)
-    set(CMAKE_CXX_FLAGS_RELEASE "${ReleaseFlags}" CACHE STRING "Release compilation options" FORCE)
-endif()
-
-# set linker flags
-get_property(LinkerFlags GLOBAL PROPERTY ArkLinkerFlags)
-if (LinkerFlags)
-    set(CMAKE_EXE_LINKER_FLAGS "${LinkerFlags}" CACHE STRING "Linker options" FORCE)
-endif()
-
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 include_directories(
     ${CMAKE_CURRENT_SOURCE_DIR}/../include
     ${PROJECT_SOURCE_DIR}/include
     ${ark_SOURCE_DIR}/thirdparty
-    ${ark_SOURCE_DIR}/include
-)
+    ${ark_SOURCE_DIR}/include)
 
 file(GLOB_RECURSE SOURCE_FILES
-    ${PROJECT_SOURCE_DIR}/src/*.cpp
-)
+    ${PROJECT_SOURCE_DIR}/src/*.cpp)
 
 set(OPENSSL_USE_STATIC_LIBS TRUE)
 find_package(OpenSSL REQUIRED)
 
-list(REMOVE_ITEM SOURCE_FILES "${PROJECT_SOURCE_DIR}/../../src/main.cpp")
-
 add_library(${PROJECT_NAME} SHARED ${SOURCE_FILES})
 
 target_link_libraries(${PROJECT_NAME} PRIVATE ArkReactor OpenSSL::Crypto OpenSSL::SSL)
-
-if (CMAKE_COMPILER_IS_GNUCXX)
-    target_link_libraries(${PROJECT_NAME} PRIVATE stdc++fs)
-endif()
-
-if (UNIX OR LINUX)
-    target_link_libraries(${PROJECT_NAME} PRIVATE ${CMAKE_DL_LIBS})
-endif()
 
 set_target_properties(
     ${PROJECT_NAME}
     PROPERTIES
         CXX_STANDARD 17
         CXX_STANDARD_REQUIRED ON
-        CXX_EXTENSIONS OFF
-)
+        CXX_EXTENSIONS OFF)
 
 add_custom_command(TARGET ${PROJECT_NAME}
     COMMAND ${CMAKE_COMMAND} -E copy
-        "$<TARGET_FILE:${PROJECT_NAME}>" ${PROJECT_SOURCE_DIR}/../../${PROJECT_NAME}.${MODULE_EXTENSION}
-)
+        "$<TARGET_FILE:${PROJECT_NAME}>" ${PROJECT_SOURCE_DIR}/../../${PROJECT_NAME}.${MODULE_EXTENSION})

--- a/json/CMakeLists.txt
+++ b/json/CMakeLists.txt
@@ -2,24 +2,6 @@ cmake_minimum_required(VERSION 3.8)
 
 project(json)
 
-# set debug compilation flags
-get_property(DebugFlags GLOBAL PROPERTY ArkDebugFlags)
-if (DebugFlags)
-    set(CMAKE_CXX_FLAGS_DEBUG "${DebugFlags}" CACHE STRING "Debug compilation options" FORCE)
-endif()
-
-# set release compilation flags
-get_property(ReleaseFlags GLOBAL PROPERTY ArkReleaseFlags)
-if (ReleaseFlags)
-    set(CMAKE_CXX_FLAGS_RELEASE "${ReleaseFlags}" CACHE STRING "Release compilation options" FORCE)
-endif()
-
-# set linker flags
-get_property(LinkerFlags GLOBAL PROPERTY ArkLinkerFlags)
-if (LinkerFlags)
-    set(CMAKE_EXE_LINKER_FLAGS "${LinkerFlags}" CACHE STRING "Linker options" FORCE)
-endif()
-
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 include_directories(
@@ -27,36 +9,22 @@ include_directories(
     ${PROJECT_SOURCE_DIR}/include
     ${ark_SOURCE_DIR}/thirdparty
     ${ark_SOURCE_DIR}/include
-    ${Modules_SOURCE_DIR}/submodules/json/single_include
-)
+    ${Modules_SOURCE_DIR}/submodules/json/single_include)
 
 file(GLOB_RECURSE SOURCE_FILES
-    ${PROJECT_SOURCE_DIR}/src/*.cpp
-)
-
-list(REMOVE_ITEM SOURCE_FILES "${PROJECT_SOURCE_DIR}/../../src/main.cpp")
+    ${PROJECT_SOURCE_DIR}/src/*.cpp)
 
 add_library(${PROJECT_NAME} SHARED ${SOURCE_FILES})
 
 target_link_libraries(${PROJECT_NAME} PRIVATE ArkReactor)
-
-if (CMAKE_COMPILER_IS_GNUCXX)
-    target_link_libraries(${PROJECT_NAME} PRIVATE stdc++fs)
-endif()
-
-if (UNIX OR LINUX)
-    target_link_libraries(${PROJECT_NAME} PRIVATE ${CMAKE_DL_LIBS})
-endif()
 
 set_target_properties(
     ${PROJECT_NAME}
     PROPERTIES
         CXX_STANDARD 17
         CXX_STANDARD_REQUIRED ON
-        CXX_EXTENSIONS OFF
-)
+        CXX_EXTENSIONS OFF)
 
 add_custom_command(TARGET ${PROJECT_NAME}
     COMMAND ${CMAKE_COMMAND} -E copy
-        "$<TARGET_FILE:${PROJECT_NAME}>" ${PROJECT_SOURCE_DIR}/../../${PROJECT_NAME}.${MODULE_EXTENSION}
-)
+        "$<TARGET_FILE:${PROJECT_NAME}>" ${PROJECT_SOURCE_DIR}/../../${PROJECT_NAME}.${MODULE_EXTENSION})

--- a/msgpack/CMakeLists.txt
+++ b/msgpack/CMakeLists.txt
@@ -2,21 +2,6 @@ cmake_minimum_required(VERSION 3.8)
 
 project(msgpack)
 
-if (CMAKE_COMPILER_IS_GNUCXX)
-    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -pg -g -no-pie")
-    set(CMAKE_CXX_FLAGS_RELEASE "-DNDEBUG -O3 -s")
-elseif (MSVC)
-    set(CMAKE_CXX_FLAGS_DEBUG "/DWIN32 /D_WINDOWS /W3 /GR /EHa /MDd" CACHE STRING "Debug compilation options" FORCE)
-    set(CMAKE_CXX_FLAGS_RELEASE "/DWIN32 /D_WINDOWS /W3 /GR /EHa /Ox /Ob2 /Oi /Ot /Oy /MD" CACHE STRING "Release compilation options" FORCE)
-endif()
-
-if (CMAKE_COMPILER_IS_GNUCXX)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wl,-rpath,/usr/local/lib")
-elseif (CMAKE_COMPILER_IS_CLANG)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++ -v")
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -stdlib=libc++ -lc++abi")
-endif()
-
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 include_directories(
@@ -24,37 +9,23 @@ include_directories(
     ${PROJECT_SOURCE_DIR}/include
     ${Ark_SOURCE_DIR}/thirdparty
     ${Ark_SOURCE_DIR}/include
-    ${Modules_SOURCE_DIR}/submodules/msgpack-cpp/include
-)
+    ${Modules_SOURCE_DIR}/submodules/msgpack-cpp/include)
 
 file(GLOB_RECURSE SOURCE_FILES
     ${PROJECT_SOURCE_DIR}/src/*.cpp
-    ${Modules_SOURCE_DIR}/submodules/msgpack-cpp/src/*.c
-)
-
-list(REMOVE_ITEM SOURCE_FILES "${PROJECT_SOURCE_DIR}/../../src/main.cpp")
+    ${Modules_SOURCE_DIR}/submodules/msgpack-cpp/src/*.c)
 
 add_library(${PROJECT_NAME} SHARED ${SOURCE_FILES})
 
 target_link_libraries(${PROJECT_NAME} PRIVATE ArkReactor)
-
-if (CMAKE_COMPILER_IS_GNUCXX)
-    target_link_libraries(${PROJECT_NAME} PRIVATE stdc++fs)
-endif()
-
-if (UNIX OR LINUX)
-    target_link_libraries(${PROJECT_NAME} PRIVATE ${CMAKE_DL_LIBS})
-endif()
 
 set_target_properties(
     ${PROJECT_NAME}
     PROPERTIES
         CXX_STANDARD 17
         CXX_STANDARD_REQUIRED ON
-        CXX_EXTENSIONS OFF
-)
+        CXX_EXTENSIONS OFF)
 
 add_custom_command(TARGET ${PROJECT_NAME}
     COMMAND ${CMAKE_COMMAND} -E copy
-        "$<TARGET_FILE:${PROJECT_NAME}>" ${PROJECT_SOURCE_DIR}/../../${PROJECT_NAME}.${MODULE_EXTENSION}
-)
+        "$<TARGET_FILE:${PROJECT_NAME}>" ${PROJECT_SOURCE_DIR}/../../${PROJECT_NAME}.${MODULE_EXTENSION})

--- a/random/CMakeLists.txt
+++ b/random/CMakeLists.txt
@@ -2,60 +2,28 @@ cmake_minimum_required(VERSION 3.8)
 
 project(random)
 
-# set debug compilation flags
-get_property(DebugFlags GLOBAL PROPERTY ArkDebugFlags)
-if (DebugFlags)
-    set(CMAKE_CXX_FLAGS_DEBUG "${DebugFlags}" CACHE STRING "Debug compilation options" FORCE)
-endif()
-
-# set release compilation flags
-get_property(ReleaseFlags GLOBAL PROPERTY ArkReleaseFlags)
-if (ReleaseFlags)
-    set(CMAKE_CXX_FLAGS_RELEASE "${ReleaseFlags}" CACHE STRING "Release compilation options" FORCE)
-endif()
-
-# set linker flags
-get_property(LinkerFlags GLOBAL PROPERTY ArkLinkerFlags)
-if (LinkerFlags)
-    set(CMAKE_EXE_LINKER_FLAGS "${LinkerFlags}" CACHE STRING "Linker options" FORCE)
-endif()
-
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 include_directories(
     ${CMAKE_CURRENT_SOURCE_DIR}/../include
     ${PROJECT_SOURCE_DIR}/include
     ${ark_SOURCE_DIR}/thirdparty
-    ${ark_SOURCE_DIR}/include
-)
+    ${ark_SOURCE_DIR}/include)
 
 file(GLOB_RECURSE SOURCE_FILES
-    ${PROJECT_SOURCE_DIR}/src/*.cpp
-)
-
-list(REMOVE_ITEM SOURCE_FILES "${PROJECT_SOURCE_DIR}/../../src/main.cpp")
+    ${PROJECT_SOURCE_DIR}/src/*.cpp)
 
 add_library(${PROJECT_NAME} SHARED ${SOURCE_FILES})
 
 target_link_libraries(${PROJECT_NAME} PRIVATE ArkReactor)
-
-if (CMAKE_COMPILER_IS_GNUCXX)
-    target_link_libraries(${PROJECT_NAME} PRIVATE stdc++fs)
-endif()
-
-if (UNIX OR LINUX)
-    target_link_libraries(${PROJECT_NAME} PRIVATE ${CMAKE_DL_LIBS})
-endif()
 
 set_target_properties(
     ${PROJECT_NAME}
     PROPERTIES
         CXX_STANDARD 17
         CXX_STANDARD_REQUIRED ON
-        CXX_EXTENSIONS OFF
-)
+        CXX_EXTENSIONS OFF)
 
 add_custom_command(TARGET ${PROJECT_NAME}
     COMMAND ${CMAKE_COMMAND} -E copy
-        "$<TARGET_FILE:${PROJECT_NAME}>" ${PROJECT_SOURCE_DIR}/../../${PROJECT_NAME}.${MODULE_EXTENSION}
-)
+        "$<TARGET_FILE:${PROJECT_NAME}>" ${PROJECT_SOURCE_DIR}/../../${PROJECT_NAME}.${MODULE_EXTENSION})

--- a/shell/createmodules/Template_CMakeLists.txt
+++ b/shell/createmodules/Template_CMakeLists.txt
@@ -2,60 +2,28 @@ cmake_minimum_required(VERSION 3.8)
 
 project(<module_name>)
 
-# set debug compilation flags
-get_property(DebugFlags GLOBAL PROPERTY ArkDebugFlags)
-if (DebugFlags)
-    set(CMAKE_CXX_FLAGS_DEBUG "${DebugFlags}" CACHE STRING "Debug compilation options" FORCE)
-endif()
-
-# set release compilation flags
-get_property(ReleaseFlags GLOBAL PROPERTY ArkReleaseFlags)
-if (ReleaseFlags)
-    set(CMAKE_CXX_FLAGS_RELEASE "${ReleaseFlags}" CACHE STRING "Release compilation options" FORCE)
-endif()
-
-# set linker flags
-get_property(LinkerFlags GLOBAL PROPERTY ArkLinkerFlags)
-if (LinkerFlags)
-    set(CMAKE_EXE_LINKER_FLAGS "${LinkerFlags}" CACHE STRING "Linker options" FORCE)
-endif()
-
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 include_directories(
     ${CMAKE_CURRENT_SOURCE_DIR}/../include
     ${PROJECT_SOURCE_DIR}/include
     ${ark_SOURCE_DIR}/thirdparty
-    ${ark_SOURCE_DIR}/include
-)
+    ${ark_SOURCE_DIR}/include)
 
 file(GLOB_RECURSE SOURCE_FILES
-    ${PROJECT_SOURCE_DIR}/src/*.cpp
-)
-
-list(REMOVE_ITEM SOURCE_FILES "${PROJECT_SOURCE_DIR}/../../src/main.cpp")
+    ${PROJECT_SOURCE_DIR}/src/*.cpp)
 
 add_library(${PROJECT_NAME} SHARED ${SOURCE_FILES})
 
 target_link_libraries(${PROJECT_NAME} PRIVATE ArkReactor)
-
-if (CMAKE_COMPILER_IS_GNUCXX)
-    target_link_libraries(${PROJECT_NAME} PRIVATE stdc++fs)
-endif()
-
-if (UNIX OR LINUX)
-    target_link_libraries(${PROJECT_NAME} PRIVATE ${CMAKE_DL_LIBS})
-endif()
 
 set_target_properties(
     ${PROJECT_NAME}
     PROPERTIES
         CXX_STANDARD 17
         CXX_STANDARD_REQUIRED ON
-        CXX_EXTENSIONS OFF
-)
+        CXX_EXTENSIONS OFF)
 
 add_custom_command(TARGET ${PROJECT_NAME}
     COMMAND ${CMAKE_COMMAND} -E copy
-        "$<TARGET_FILE:${PROJECT_NAME}>" ${PROJECT_SOURCE_DIR}/../../${PROJECT_NAME}.${MODULE_EXTENSION}
-)
+        "$<TARGET_FILE:${PROJECT_NAME}>" ${PROJECT_SOURCE_DIR}/../../${PROJECT_NAME}.${MODULE_EXTENSION})


### PR DESCRIPTION
Rewriting the CMake rules to work with https://github.com/ArkScript-lang/Ark/pull/313.

As the compiler options are now made public, their is no need to set them for each module, which are linking against ArkReactor, thus getting its compiler & linker options.