### PR TITLE
Database: New module for SQLite Database interaction

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ set(ARK_MOD_HTTP    Off CACHE BOOL "Build the http module")
 set(ARK_MOD_JSON    Off CACHE BOOL "Build the json module")
 set(ARK_MOD_HASH    Off CACHE BOOL "Build the hash module")
 set(ARK_MOD_BITWISE    Off CACHE BOOL "Build the bitwise module")
+set(ARK_MOD_DATABASE   Off CACHE BOOL "Build the database module")
 set(ARK_MOD_ALL     Off CACHE BOOL "Build all the modules")
 
 if (ARK_MOD_RAND OR ARK_MOD_ALL)
@@ -39,4 +40,8 @@ endif()
 
 if (ARK_MOD_BITWISE OR ARK_MOD_ALL)
     add_subdirectory(${PROJECT_SOURCE_DIR}/bitwise)
+endif()
+
+if (ARK_MOD_DATABASE OR ARK_MOD_ALL)
+    add_subdirectory(${PROJECT_SOURCE_DIR}/database)
 endif()

--- a/database/CMakeLists.txt
+++ b/database/CMakeLists.txt
@@ -1,0 +1,32 @@
+cmake_minimum_required(VERSION 3.8)
+
+project(database)
+
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+find_package(SQLite3)
+
+include_directories(
+    ${PROJECT_SOURCE_DIR}/../include
+    ${PROJECT_SOURCE_DIR}/include
+    ${ark_SOURCE_DIR}/thirdparty
+    ${ark_SOURCE_DIR}/include
+    ${SQLite3_INCLUDE_DIRS})
+
+file(GLOB_RECURSE SOURCE_FILES
+    ${PROJECT_SOURCE_DIR}/src/*.cpp)
+
+add_library(${PROJECT_NAME} SHARED ${SOURCE_FILES})
+
+target_link_libraries(${PROJECT_NAME} PRIVATE ArkReactor ${SQLite3_LIBRARIES})
+
+set_target_properties(
+    ${PROJECT_NAME}
+    PROPERTIES
+        CXX_STANDARD 17
+        CXX_STANDARD_REQUIRED ON
+        CXX_EXTENSIONS OFF)
+
+add_custom_command(TARGET ${PROJECT_NAME}
+    COMMAND ${CMAKE_COMMAND} -E copy
+        "$<TARGET_FILE:${PROJECT_NAME}>" ${PROJECT_SOURCE_DIR}/../../${PROJECT_NAME}.${MODULE_EXTENSION})

--- a/database/documentation/README.md
+++ b/database/documentation/README.md
@@ -1,0 +1,98 @@
+@page database_module DATABASE module
+
+## database:sqlite:open
+
+Open a connection to a SQLite database.
+
+**Parameters**
+- `database_filename`: path to the database file
+
+**Return value** `UserType`: an open connection to a SQLite database
+
+**Author**
+- [@rstefanic](https://github.com/rstefanic)
+
+**Example**
+~~~~{.lisp}
+(let db (database:sqlite:open "test.db"))
+~~~~
+
+## database:sqlite:close
+
+Close an open connection to a SQLite database.
+
+**Parameters**
+- `database`: an open SQLite database object
+
+**Return value** `number`: SQLite exit code (0 on success).
+
+**Author**
+- [@rstefanic](https://github.com/rstefanic)
+
+**Example**
+~~~~{.lisp}
+(database:sqlite:close db)
+~~~~
+
+## database:sqlite:exec
+
+Execute a SQL query.
+
+**Parameters**
+- `database`: an open SQLite database object
+- `sql`: SQL statement(s)
+
+**Return value** `number`: SQLite exit code (0 on success).
+
+**Author**
+- [@rstefanic](https://github.com/rstefanic)
+
+**Example**
+~~~~{.lisp}
+(database:sqlite:exec db "CREATE TABLE company(id INT PRIMARY KEY NOT NULL, name TEXT NOT NULL);")
+~~~~
+
+## database:sqlite:exec_with_callback
+
+Run a SQL statement on the database and run a callback function on each row in the results. The callback function takes one argument which will be passed a list of the results from a row.
+
+**Parameters**
+- `database`: SQLite Object
+- `sql`: a string of the query or queries that you'd like to run
+- `callback`: a function to run on every row returned
+
+**Return value** `number`: SQLite exit code.
+
+**Author**
+- [@rstefanic](https://github.com/rstefanic)
+
+**Example**
+~~~~{.lisp}
+# CREATE TABLE user (id INT PRIMARY KEY NOT NULL, name TEXT NOT NULL);
+# INSERT INTO user (id, name) VALUES (1, 'Jane Doe'), (2, 'John Doe');
+
+(database:sqlite:exec_with_callback
+  db
+  "SELECT * FROM user;"
+  (fun (row) (print row))
+)
+# ["1" "Jane Doe"]
+# ["2" "John Doe"]
+~~~~
+
+## database:sqlite:last_insert_row_id
+
+Get the row id of the last row inserted into the database.
+
+**Parameters**
+- `database`: SQLite Object
+
+**Return value** `number`: id of the last row inserted
+
+**Author**
+- [@rstefanic](https://github.com/rstefanic)
+
+**Example**
+~~~~{.lisp}
+(database:sqlite:last_insert_row_id db)
+~~~~

--- a/database/include/database.hpp
+++ b/database/include/database.hpp
@@ -1,0 +1,18 @@
+#ifndef database_module
+#define database_module
+
+#include <Ark/Module.hpp>
+
+#include <stdio.h>
+#include <sqlite3.h>
+
+namespace Database
+{
+    Value database_sqlite_open(std::vector<Value>& args, Ark::VM* vm);
+    Value database_sqlite_close(std::vector<Value>& args, Ark::VM* vm);
+    Value database_sqlite_exec(std::vector<Value>& args, Ark::VM* vm);
+    Value database_sqlite_exec_with_callback(std::vector<Value>& args, Ark::VM* vm);
+    Value database_sqlite_last_insert_row_id(std::vector<Value>& args, Ark::VM* vm);
+}
+
+#endif

--- a/database/src/main.cpp
+++ b/database/src/main.cpp
@@ -1,0 +1,15 @@
+#include <database.hpp>
+
+ARK_API mapping* getFunctionsMapping()
+{
+    mapping* map = mapping_create(5);
+
+    // Sqlite3
+    mapping_add(map[0], "database:sqlite:open", Database::database_sqlite_open);
+    mapping_add(map[1], "database:sqlite:close", Database::database_sqlite_close);
+    mapping_add(map[2], "database:sqlite:exec", Database::database_sqlite_exec);
+    mapping_add(map[3], "database:sqlite:exec_with_callback", Database::database_sqlite_exec_with_callback);
+    mapping_add(map[4], "database:sqlite:last_insert_row_id", Database::database_sqlite_last_insert_row_id);
+
+    return map;
+}

--- a/database/src/sqlite3.cpp
+++ b/database/src/sqlite3.cpp
@@ -1,0 +1,121 @@
+#include <database.hpp>
+
+namespace Database
+{
+    Value database_sqlite_open(std::vector<Value>& args, Ark::VM* vm [[maybe_unused]])
+    {
+        if (!types::check(args, ValueType::String))
+            types::generateError(
+                "database:sqlite:open",
+                { { types::Contract { { types::Typedef("database_filename", ValueType::String) } } } },
+                args);
+
+        sqlite3* db;
+        const char* database_name = args[0].string().c_str();
+
+        if (sqlite3_open(database_name, &db) != SQLITE_OK)
+            return Nil;
+
+        return Ark::Value(Ark::UserType(db));
+    }
+
+    Value database_sqlite_close(std::vector<Value>& args, Ark::VM* vm [[maybe_unused]])
+    {
+        if (!types::check(args, ValueType::User) || !args[0].usertype().is<sqlite3>())
+            types::generateError(
+                "database:sqlite:close",
+                { { types::Contract { { types::Typedef("database", ValueType::User) } } } },
+                args);
+
+        sqlite3* db = (sqlite3*)args[0].usertypeRef().data();
+        return Ark::Value(sqlite3_close(db));
+    }
+
+    Value database_sqlite_exec(std::vector<Value>& args, Ark::VM* vm [[maybe_unused]])
+    {
+        if (!types::check(args, ValueType::User, ValueType::String) || !args[0].usertype().is<sqlite3>())
+            types::generateError(
+                "database:sqlite:exec",
+                { { types::Contract { { types::Typedef("database", ValueType::User),
+                                        types::Typedef("sql", ValueType::String) } } } },
+                args);
+
+        sqlite3* db = (sqlite3*)args[0].usertypeRef().data();
+        const char* sql = args[1].string().c_str();
+        char* error_message = nullptr;
+
+        int code = sqlite3_exec(db, sql, nullptr, nullptr, &error_message);
+        if (code != SQLITE_OK)
+        {
+            std::runtime_error error = std::runtime_error(
+                "database:sqlite:exec: exited with code " + std::to_string(code) + "\n" + std::string(error_message));
+            sqlite3_free(error_message);
+            throw error;
+        }
+
+        return Ark::Value(code);
+    }
+
+    Value database_sqlite_exec_with_callback(std::vector<Value>& args, Ark::VM* vm [[maybe_unused]])
+    {
+        if (args.size() != 3 || !args[0].usertype().is<sqlite3>() || args[1].valueType() != ValueType::String || !args[2].isFunction())
+            types::generateError(
+                "database:sqlite:exec_with_callback",
+                { { types::Contract { { types::Typedef("database", ValueType::User),
+                                        types::Typedef("sql", ValueType::String),
+                                        types::Typedef("callback", ValueType::Closure) } } } },
+                args);
+
+        sqlite3* db = (sqlite3*)args[0].usertypeRef().data();
+        const char* sql = args[1].string().c_str();
+        const Ark::Value user_defined_callback = args[2];
+
+        // 'sqlite3_exec' accepts a callback function which we will define here. This callback is invoked for
+        // each result row coming out of the evaluated SQL statement(s). The first argument is a void*
+        // where we can pass a pointer to a vector containing all the results.
+        auto callback = [](void* all_results, int argc, char** argv, char** col_names [[maybe_unused]]) -> int {
+            auto all_results_casted = static_cast<std::vector<std::vector<Ark::Value>>*>(all_results);
+            std::vector<Ark::Value> current_row;
+
+            // Add each element as an Ark String to the current row results
+            for (int i = 0; i < argc; i++)
+                current_row.push_back(Ark::Value(std::string(argv[i])));
+
+            // Add the current row to our collection of results
+            all_results_casted->push_back(current_row);
+            return 0;
+        };
+
+        char* error_message = nullptr;
+        std::vector<std::vector<Ark::Value>> all_results;
+        int code = sqlite3_exec(db, sql, callback, &all_results, &error_message);
+
+        // For each row returned from the SQL query, run the user's callback
+        // function on each row passing in an Ark List of the row results.
+        for (std::vector<Ark::Value> row : all_results)
+            vm->resolve(&user_defined_callback, Ark::Value(std::vector<Ark::Value>(row.begin(), row.end())));
+
+        if (code != SQLITE_OK)
+        {
+            std::runtime_error error = std::runtime_error(
+                "database:sqlite:exec: exited with code " + std::to_string(code) + "\n" + std::string(error_message));
+            sqlite3_free(error_message);
+            throw error;
+        }
+
+        return Ark::Value(code);
+    }
+
+    Value database_sqlite_last_insert_row_id(std::vector<Value>& args, Ark::VM* vm [[maybe_unused]])
+    {
+        if (!types::check(args, ValueType::User) || !args[0].usertype().is<sqlite3>())
+            types::generateError(
+                "database:sqlite:last_insert_row_id",
+                { { types::Contract { { types::Typedef("database", ValueType::User) } } } },
+                args);
+
+        sqlite3* db = (sqlite3*)args[0].usertypeRef().data();
+        int row_id = sqlite3_last_insert_rowid(db);
+        return Ark::Value(row_id);
+    }
+}

--- a/database/src/sqlite3.cpp
+++ b/database/src/sqlite3.cpp
@@ -58,7 +58,7 @@ namespace Database
 
     Value database_sqlite_exec_with_callback(std::vector<Value>& args, Ark::VM* vm [[maybe_unused]])
     {
-        if (args.size() != 3 || !args[0].usertype().is<sqlite3>() || args[1].valueType() != ValueType::String || !args[2].isFunction())
+        if (args.size() != 3 || args[0].valueType() != ValueType::User || !args[0].usertype().is<sqlite3>() || args[1].valueType() != ValueType::String || !args[2].isFunction())
             types::generateError(
                 "database:sqlite:exec_with_callback",
                 { { types::Contract { { types::Typedef("database", ValueType::User),

--- a/database/src/sqlite3.cpp
+++ b/database/src/sqlite3.cpp
@@ -92,8 +92,8 @@ namespace Database
 
         // For each row returned from the SQL query, run the user's callback
         // function on each row passing in an Ark List of the row results.
-        for (std::vector<Ark::Value> row : all_results)
-            vm->resolve(&user_defined_callback, Ark::Value(std::vector<Ark::Value>(row.begin(), row.end())));
+        for (std::vector<Ark::Value>& row : all_results)
+            vm->resolve(&user_defined_callback, Ark::Value(std::move(row)));
 
         if (code != SQLITE_OK)
         {

--- a/database/src/sqlite3.cpp
+++ b/database/src/sqlite3.cpp
@@ -27,8 +27,8 @@ namespace Database
                 { { types::Contract { { types::Typedef("database", ValueType::User) } } } },
                 args);
 
-        sqlite3* db = (sqlite3*)args[0].usertypeRef().data();
-        return Ark::Value(sqlite3_close(db));
+        sqlite3& db = args[0].usertypeRef().as<sqlite3>();
+        return Ark::Value(sqlite3_close(&db));
     }
 
     Value database_sqlite_exec(std::vector<Value>& args, Ark::VM* vm [[maybe_unused]])
@@ -40,11 +40,11 @@ namespace Database
                                         types::Typedef("sql", ValueType::String) } } } },
                 args);
 
-        sqlite3* db = (sqlite3*)args[0].usertypeRef().data();
+        sqlite3& db = args[0].usertypeRef().as<sqlite3>();
         const char* sql = args[1].string().c_str();
         char* error_message = nullptr;
 
-        int code = sqlite3_exec(db, sql, nullptr, nullptr, &error_message);
+        int code = sqlite3_exec(&db, sql, nullptr, nullptr, &error_message);
         if (code != SQLITE_OK)
         {
             std::runtime_error error = std::runtime_error(
@@ -66,7 +66,7 @@ namespace Database
                                         types::Typedef("callback", ValueType::Closure) } } } },
                 args);
 
-        sqlite3* db = (sqlite3*)args[0].usertypeRef().data();
+        sqlite3& db = args[0].usertypeRef().as<sqlite3>();
         const char* sql = args[1].string().c_str();
         const Ark::Value user_defined_callback = args[2];
 
@@ -88,7 +88,7 @@ namespace Database
 
         char* error_message = nullptr;
         std::vector<std::vector<Ark::Value>> all_results;
-        int code = sqlite3_exec(db, sql, callback, &all_results, &error_message);
+        int code = sqlite3_exec(&db, sql, callback, &all_results, &error_message);
 
         // For each row returned from the SQL query, run the user's callback
         // function on each row passing in an Ark List of the row results.
@@ -114,8 +114,8 @@ namespace Database
                 { { types::Contract { { types::Typedef("database", ValueType::User) } } } },
                 args);
 
-        sqlite3* db = (sqlite3*)args[0].usertypeRef().data();
-        int row_id = sqlite3_last_insert_rowid(db);
+        sqlite3& db = args[0].usertypeRef().as<sqlite3>();
+        int row_id = sqlite3_last_insert_rowid(&db);
         return Ark::Value(row_id);
     }
 }

--- a/database/tests/main.ark
+++ b/database/tests/main.ark
@@ -1,0 +1,18 @@
+(import "database.arkm")
+
+(let db (database:sqlite:open "test.db"))
+
+(assert (= 0 (database:sqlite:exec db "CREATE TABLE company(id INT PRIMARY KEY NOT NULL, name TEXT NOT NULL, country TEXT NOT NULL);")) "database:sqlite:exec")
+(assert (= 0 (database:sqlite:exec db "INSERT INTO company (id, name, country) VALUES (1, 'Erdman Group', 'France');")) "database:sqlite:exec")
+(assert (= 0 (database:sqlite:exec db "INSERT INTO company (id, name, country) VALUES (2, 'Wiza Ltd', 'United States');")) "database:sqlite:exec")
+(assert (= 0 (database:sqlite:exec db "INSERT INTO company (id, name, country) VALUES (3, 'Buckridge Inc', 'Spain');")) "database:sqlite:exec")
+(assert (= 3 (database:sqlite:last_insert_row_id db)) "database:sqlite:last_insert_row_id")
+
+# The 'company' table has three columns, so each row should return a list with three elements
+(database:sqlite:exec_with_callback
+    db
+    "SELECT * FROM company;"
+    (fun (row)
+      (assert (= 3 (len row)) "database:sqlite:exec_with_callback")))
+
+(database:sqlite:close db)

--- a/database/tests/run
+++ b/database/tests/run
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+ARKSCRIPT=$1
+ARKLIB=$2
+
+delete_test_db_if_exists()
+{
+    if [ -f ./test.db ]; then
+        rm ./test.db
+    fi
+}
+
+# Delete any existing test database if it exists
+delete_test_db_if_exists
+
+$ARKSCRIPT main.ark --lib $ARKLIB
+
+# Clean up test database after run
+delete_test_db_if_exists


### PR DESCRIPTION
This is the start of a Database module which adds support for SQLite databases. There was a discussion (#10) about adding support for a couple of different types of SQL databases. Part of the reason I picked SQLite was because it was easy to think of a way to write tests for it. :stuck_out_tongue:

Currently this implementation supports opening a connection to a SQLite database, closing a connection, running queries in a couple of different ways, and getting the id of the last row inserted into the SQLite database.

There's a lot more that we would need to add before SQLite is fully supported, but this is a decent start.